### PR TITLE
fix: KeyError: 'monitor'

### DIFF
--- a/pyrcrack/models.py
+++ b/pyrcrack/models.py
@@ -39,7 +39,7 @@ class Interface:
 
     @property
     def monitor(self):
-        return self.data['monitor']['interface']
+        return self.data['interface']
 
     def asdict(self):
         return self.data


### PR DESCRIPTION
The readme example returns KeyError: 'monitor' due to the monitor key not existing. It works after removing the monitor key and accessing the interface key directly, but I'm not sure if this is intended.