### PR TITLE
Update models.py to accommodate the latest change

### DIFF
--- a/pyrcrack/models.py
+++ b/pyrcrack/models.py
@@ -39,7 +39,7 @@ class Interface:
 
     @property
     def monitor(self):
-        return self.data['monitor']['interface']
+        return self.data['interface']
 
     def asdict(self):
         return self.data


### PR DESCRIPTION
It was giving error in aexit of Airmon initilization, this was due to the fact that there was no separate Airmon ng monitor interface, instead it is same as original interface name, did some typo to reflect it, please review