### PR TITLE
feat: :sparkles: #29 Improved airmon-ng interface

### DIFF
--- a/pyrcrack/__init__.py
+++ b/pyrcrack/__init__.py
@@ -3,6 +3,7 @@
 Aircrack-NG python bindings
 """
 import subprocess
+from contextvars import ContextVar
 
 from .aircrack import AircrackNg  # noqa
 from .airdecap import AirdecapNg  # noqa
@@ -11,6 +12,8 @@ from .airmon import AirmonNg  # noqa
 from .airbase import AirbaseNg  # noqa
 from .airdecloack import AirdecloackNg  # noqa
 from .airodump import AirodumpNg  # noqa
+
+MONITOR = ContextVar('monitor_interface')
 
 
 def check():

--- a/pyrcrack/airmon.py
+++ b/pyrcrack/airmon.py
@@ -1,4 +1,5 @@
 """Airmon-ng"""
+import re
 import asyncio
 from .executor import ExecutorHelper
 from .models import Interfaces
@@ -16,6 +17,7 @@ class AirmonNg(ExecutorHelper):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.dirty = False
+        self.monitor_token = None
         self.monitor_enabled = []
 
     async def run(self, *args, **kwargs):
@@ -23,6 +25,7 @@ class AirmonNg(ExecutorHelper):
         self.dirty = True
         if args:
             assert any(a in args[0] for a in ('start', 'stop', 'check'))
+
         return await super().run(*args, **kwargs)
 
     async def __aenter__(self):
@@ -31,17 +34,30 @@ class AirmonNg(ExecutorHelper):
             raise RuntimeError('Should be called (airmon()) first.')
         ifaces = await self.interfaces
         if not any(a.interface == self.run_args[0][0] for a in ifaces):
-            raise ValueError('Invalid interface selected')
+            if not any(a == self.run_args[0][0] for a in ifaces):
+                raise ValueError('Invalid interface selected')
         await self.run('start', self.run_args[0][0])
         # Save interface data while we're on the async cm.
         self._interface_data = await self.interfaces
+        from . import MONITOR
+        self.monitor_token = MONITOR.set(self.monitor_interface)
         return self
+
+    async def select_interface(self, regex):
+        ifaces = await self.interfaces
+        reg = re.compile(regex)
+        if interface := next((a for a in ifaces if reg.match(str(a))), None):
+            return interface
+        raise Exception(f'No interface matching regex {regex}')
 
     async def __aexit__(self, *args, **kwargs):
         """Set monitor-enabled interfaces back to normal"""
         await self.run('stop', self.monitor_interface)
         self.dirty = False
         await asyncio.sleep(1)
+        if self.monitor_token:
+            from . import MONITOR
+            MONITOR.reset(self.monitor_token)
         await self.interfaces
 
     @property
@@ -64,4 +80,8 @@ class AirmonNg(ExecutorHelper):
         if not self.dirty:
             await self.run()
             self.dirty = False
-        return Interfaces(await self.readlines())
+        data = await self.readlines()
+        return Interfaces(data)
+
+    def __str__(self):
+        return self.monitor_interface

--- a/pyrcrack/airodump.py
+++ b/pyrcrack/airodump.py
@@ -120,7 +120,10 @@ class AirodumpNg(ExecutorHelper):
         except asyncio.exceptions.TimeoutError:
             # No file had been generated or process hadn't started in 3
             # seconds.
-            raise Exception(await self.proc.communicate())
+            res = "Unknown"
+            if self.proc:
+                res = await self.proc.communicate()
+            raise Exception('\n'.join([a.decode() for a in res]))
 
         while self.running:
             # Avoid crashing on file creation
@@ -139,3 +142,4 @@ class AirodumpNg(ExecutorHelper):
                 return Result([])
 
             await asyncio.sleep(1)
+        return Result([])

--- a/pyrcrack/executor.py
+++ b/pyrcrack/executor.py
@@ -17,6 +17,7 @@ logging.basicConfig(level=logging.INFO)
 
 class Option:
     """Represents a single option (e.g, -e)."""
+
     def __init__(self, usage, word=None, value=None, logger=None):
         """Set option parameters."""
         self.usage = usage
@@ -65,6 +66,7 @@ class Option:
 
 class ExecutorHelper:
     """Abstract class interface to a shell command."""
+
     def __init__(self):
         """Set docstring."""
         if not self.__doc__:

--- a/pyrcrack/models.py
+++ b/pyrcrack/models.py
@@ -41,15 +41,25 @@ class Interface:
     def interface(self):
         return self.data['interface']
 
+    def __eq__(self, other):
+        if isinstance(other, Interface):
+            return other.interface == self.interface
+        return self.interface == other
+
     @property
     def monitor(self):
-        return self.data['interface']
+        return self.data.get('monitor', {}).get('interface',
+                                                self.data['interface'])
 
     def asdict(self):
         return self.data
 
+    def __str__(self):
+        return self.interface
+
 
 class Interfaces(Result):
+
     def __init__(self, data):
         if data == [b'Run it as root']:
             raise Exception('Pyrcrack must be run as root')


### PR DESCRIPTION
- Added contextvars, you don't need to save te current monitor
  interface, as long as you're withing the airmon's contextmanager, you
  can not-store the current selected monitor interface, and just pass
  pyrcrack.MONITOR as interface. This way you can call methods without
  having to pass the monitor interface along.
- Added "select_interface" method that receives a regex.
- Casting an airmon-ng object to string now returns the monitor
  interface
- Made it so, whenever we have  monitor interface available, we operate
  with it.

The latest commit is related with
217b8447a90036239bafe677cd976e8880e73046 by Harishankar Kumar, that
actually broke my setup.

I'm guessing there's a difference between how our systems handle monitor
interfaces. Will have to further investigate, re-open the bug and get it
done there.

It *should* be reusable as-is, but anyway, I've added a similar fix as a
fallback just in case there's no monitor interface data for some weird
reason

Before submitting your PR, please review the following checklist:

- [x] I have passed apf with default options must be run before submitting any PR
- [x] Tests pass
- [x] Coverage hasn't lowered
