### PR TITLE
feat: :sparkles: Check correct aircrack version and root

### DIFF
--- a/pyrcrack/__init__.py
+++ b/pyrcrack/__init__.py
@@ -2,7 +2,6 @@
 
 Aircrack-NG python bindings
 """
-import subprocess
 from contextvars import ContextVar
 
 from .aircrack import AircrackNg  # noqa
@@ -14,8 +13,3 @@ from .airdecloack import AirdecloackNg  # noqa
 from .airodump import AirodumpNg  # noqa
 
 MONITOR = ContextVar('monitor_interface')
-
-
-def check():
-    """Check if aircrack-ng is compatible."""
-    assert '1.6' in subprocess.check_output(['aircrack-ng', '-v'])

--- a/pyrcrack/airbase.py
+++ b/pyrcrack/airbase.py
@@ -50,3 +50,4 @@ class AirbaseNg(ExecutorHelper):
     command = 'airbase-ng'
     requires_tempfile = False
     requires_tempdir = False
+    requires_root = True

--- a/pyrcrack/aircrack.py
+++ b/pyrcrack/aircrack.py
@@ -57,6 +57,7 @@ class AircrackNg(ExecutorHelper):
     command = "aircrack-ng"
     requires_tempfile = True
     requires_tempdir = False
+    requires_root = False
 
     async def run(self, *args, **kwargs):
         if self.tempfile:
@@ -65,5 +66,7 @@ class AircrackNg(ExecutorHelper):
 
     async def get_result(self):
         """Read tempfile (write key result)"""
-        await self.proc.wait()
-        return self.tempfile.read()
+        if self.proc:
+            await self.proc.wait()
+        if self.tempfile:
+            return self.tempfile.read()

--- a/pyrcrack/airdecap.py
+++ b/pyrcrack/airdecap.py
@@ -27,3 +27,4 @@ class AirdecapNg(ExecutorHelper):
     sync = False
     requires_tempfile = False
     requires_tempdir = False
+    requires_root = False

--- a/pyrcrack/airdecloack.py
+++ b/pyrcrack/airdecloack.py
@@ -41,3 +41,4 @@ class AirdecloackNg(ExecutorHelper):
     command = "airdecloack-ng"
     requires_tempfile = False
     requires_tempdir = False
+    requires_root = False

--- a/pyrcrack/aireplay.py
+++ b/pyrcrack/aireplay.py
@@ -62,6 +62,7 @@ class AireplayNg(ExecutorHelper):
     command = 'aireplay-ng'
     requires_tempfile = False
     requires_tempdir = False
+    requires_root = True
 
     async def run(self, *args, **kwargs):
         """Run async, with prefix stablished as tempdir."""

--- a/pyrcrack/airmon.py
+++ b/pyrcrack/airmon.py
@@ -13,6 +13,7 @@ class AirmonNg(ExecutorHelper):
     command = 'airmon-ng'
     requires_tempfile = False
     requires_tempdir = False
+    requires_root = True
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/pyrcrack/airodump.py
+++ b/pyrcrack/airodump.py
@@ -69,6 +69,7 @@ class AirodumpNg(ExecutorHelper):
     """
     requires_tempfile = False
     requires_tempdir = True
+    requires_root = True
     command = "airodump-ng"
 
     async def run(self, *args, **kwargs):

--- a/pyrcrack/executor.py
+++ b/pyrcrack/executor.py
@@ -95,10 +95,11 @@ class ExecutorHelper:
             self.tempfile = tempfile.NamedTemporaryFile()
         elif self.requires_tempdir:
             self.tempdir = tempfile.TemporaryDirectory()
-        if self.requires_root:
+        if self.requires_root and not os.getenv("SKIP_ROOT_CHECK"):
             if os.geteuid() != 0:
                 raise Exception("Must be run as root")
-        check()
+        if not os.getenv('SKIP_VERSION_CHECK'):
+            check()
 
     @property
     @functools.lru_cache()

--- a/pyrcrack/executor.py
+++ b/pyrcrack/executor.py
@@ -1,7 +1,6 @@
 """Pyrcrack-ng Executor helper."""
 
 import os
-import abc
 import asyncio
 import functools
 import itertools
@@ -66,8 +65,18 @@ class Option:
         return f"Option(<{self.parsed}>, {self.is_short}, {self.expects_args})"
 
 
+def check():
+    """Check if aircrack-ng is compatible."""
+    assert b'Aircrack-ng 1.6' in subprocess.check_output(
+        ['aircrack-ng', '--help'])
+
+
 class ExecutorHelper:
     """Abstract class interface to a shell command."""
+    requires_tempfile = False
+    requires_tempdir = False
+    requires_root = True
+    command = ''
 
     def __init__(self):
         """Set docstring."""
@@ -86,18 +95,10 @@ class ExecutorHelper:
             self.tempfile = tempfile.NamedTemporaryFile()
         elif self.requires_tempdir:
             self.tempdir = tempfile.TemporaryDirectory()
-
-    @abc.abstractproperty
-    def requires_tempfile(self):
-        """Synchronous mode."""
-
-    @abc.abstractproperty
-    def requires_tempdir(self):
-        """Synchronous mode."""
-
-    @abc.abstractproperty
-    def command(self):
-        """Specify command to execute."""
+        if self.requires_root:
+            if os.geteuid() != 0:
+                raise Exception("Must be run as root")
+        check()
 
     @property
     @functools.lru_cache()

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,3 @@
+import os
+os.environ['SKIP_ROOT_CHECK'] = "1"
+os.environ['SKIP_VERSION_CHECK'] = "1"

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -17,6 +17,7 @@ def test_helpstr_extraction():
             command = "foobar"
             requires_tempfile = False
             requires_tempdir = False
+            requires_root = False
 
         assert FakeExecutor().helpstr == 'test'
         mock.assert_called_with("foobar 2>&1; echo", shell=True)
@@ -42,6 +43,7 @@ def test_usage():
             command = "foobar"
             requires_tempfile = False
             requires_tempdir = False
+            requires_root = False
 
         assert FakeExecutor().usage == {'-f': False, '-y': True}
 
@@ -65,6 +67,7 @@ async def test_run_async():
             command = "foobar"
             requires_tempfile = False
             requires_tempdir = False
+            requires_root = False
 
         await FakeExecutor().run(f="foo", y=True)
 


### PR DESCRIPTION
closes: #40

On ExecutorHelper's __init__ method, two checks have been added:

- Aircrack-ng version must be 1.6
- On some commands, root is required, we check it by getting effective
  uid.

Finally, all commands have a new "requires_root" class property.

Before submitting your PR, please review the following checklist:

- [ ] I have passed apf with default options must be run before submitting any PR
- [ ] Tests pass
- [ ] Coverage hasn't lowered
