### PR TITLE
Check if aireplay actually returned any data before updating result

### DIFF
--- a/pyrcrack/models.py
+++ b/pyrcrack/models.py
@@ -207,7 +207,9 @@ class AireplayResult(dict):
     """Single aiplay result line."""
 
     def __init__(self, *args, **kwargs):
-        self.update(parse(APL_FMT, kwargs.pop("_data")).named)
+        data = parse(APL_FMT, kwargs.pop("_data"))
+        if data:
+            self.update(data.named)
         super().__init__(*args, **kwargs)
 
     def asdict(self):


### PR DESCRIPTION
e.g. on abort which right now throws an unretrievable AttributeError in the coroutine:

```python
2023-12-04 12:50:32,677 base_events[default_exception_handler]   ERROR: Task exception was never retrieved
future: <Task finished name='Task-25' coro=<AireplayNg.result_updater() done, defined at /home/defkev/pyrcrack-venv/lib/python3.11/site-packages/pyrcrack/aireplay.py:76> exception=AttributeError("'NoneType' object has no attribute 'named'")>
Traceback (most recent call last):
  File "/home/defkev/pyrcrack-venv/lib/python3.11/site-packages/pyrcrack/aireplay.py", line 84, in result_updater
    self.meta["result"] = await self.get_results()
                          ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/defkev/pyrcrack-venv/lib/python3.11/site-packages/pyrcrack/aireplay.py", line 91, in get_results
    return AireplayResults((await self.proc.communicate())[0].decode())
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/defkev/pyrcrack-venv/lib/python3.11/site-packages/pyrcrack/models.py", line 221, in __init__
    self.extend((AireplayResult(_data=a) for a in data.split("\n")
  File "/home/defkev/pyrcrack-venv/lib/python3.11/site-packages/pyrcrack/models.py", line 221, in <genexpr>
    self.extend((AireplayResult(_data=a) for a in data.split("\n")
                 ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/defkev/pyrcrack-venv/lib/python3.11/site-packages/pyrcrack/models.py", line 210, in __init__
    self.update(parse(APL_FMT, kwargs.pop("_data")).named)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'named'
```

This "could" be further improved by streaming the output of aireplay (instead of waiting for its completion) which then would allow us to add other "plugins" like mdk4 [1] which is supposed to be run indefinitly (until keyboard interrupted)

[1] https://github.com/aircrack-ng/mdk4